### PR TITLE
added passing test and done_testing to stop test failure

### DIFF
--- a/t/03_badhost.t
+++ b/t/03_badhost.t
@@ -3,4 +3,5 @@
 use Test::More;
 use Test::RequiresInternet ( 'foobar' => 80 );
 
-
+ok(1);
+done_testing();


### PR DESCRIPTION
Install from CPAN was failing using Test::More 1.001006, Perl 5.16.3, Fedora 17:

```
$ prove -l t/03_badhost.t 
t/03_badhost.t .. No subtests run 

Test Summary Report
-------------------
t/03_badhost.t (Wstat: 0 Tests: 0 Failed: 0)
  Parse errors: No plan found in TAP output
Files=1, Tests=0,  0 wallclock secs ( 0.02 usr  0.00 sys +  0.01 cusr  0.00 csys =  0.03 CPU)
Result: FAIL
```
