### PR TITLE
done_testing requires Test::More 0.88 or later

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,9 @@ version 0.03
     use Test::RequiresInternet ('www.example.com' => 80, 'foobar.io' => 25);
 
     # if you reach here, sockets successfully connected to hosts/ports above
+    plan tests => 1;
 
     ok(do_that_internet_thing());
-
-    done_testing();
 
 # OVERVIEW
 

--- a/lib/Test/RequiresInternet.pm
+++ b/lib/Test/RequiresInternet.pm
@@ -10,10 +10,9 @@ package Test::RequiresInternet;
   use Test::RequiresInternet ('www.example.com' => 80, 'foobar.io' => 25);
 
   # if you reach here, sockets successfully connected to hosts/ports above
+  plan tests => 1;
 
   ok(do_that_internet_thing());
-
-  done_testing();
 
 =head1 OVERVIEW
 

--- a/t/01_getserv.t
+++ b/t/01_getserv.t
@@ -3,6 +3,7 @@
 use Test::More;
 use Test::RequiresInternet ( 'www.google.com' => 'http' );
 
+plan tests => 1;
+
 ok(1);
 
-done_testing();

--- a/t/02_multiple_hosts.t
+++ b/t/02_multiple_hosts.t
@@ -3,5 +3,6 @@
 use Test::More;
 use Test::RequiresInternet ( 'www.google.com' => 80, 'www.yahoo.com' => 80 );
 
+plan tests => 1;
+
 ok(1);
-done_testing();

--- a/t/03_badhost.t
+++ b/t/03_badhost.t
@@ -3,5 +3,6 @@
 use Test::More;
 use Test::RequiresInternet ( 'foobar' => 80 );
 
+plan tests => 1;
+
 ok(1);
-done_testing();

--- a/t/05_badarg.t
+++ b/t/05_badarg.t
@@ -1,6 +1,6 @@
 #!perl
 
-use Test::More;
+use Test::More tests => 1;
 require Test::RequiresInternet;
 
 eval {
@@ -10,5 +10,4 @@ eval {
 diag $@;
 
 ok( $@ ? 1 : 0 );
-done_testing();
 


### PR DESCRIPTION
Either the metadata should be tweaked to reflect the dependency
version, or this change could be applied to use a plan instead
of done_testing and hence run with older versions of Test::More.

