### PR TITLE
Fix tests when NO_NETWORK_TESTING set

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Change history for Test-RequiresInternet
 
 {{$NEXT}}
+            Fix test error when NO_NETWORK_TESTING is set (Karen Etheridge,
+            RT#101996, GH#3)
 
 0.04        2015-01-29
             2015-01-29

--- a/t/05_badarg.t
+++ b/t/05_badarg.t
@@ -10,7 +10,8 @@ eval {
         Test::RequiresInternet->import('www.google.com');
 };
 
-diag $@;
-
-ok( $@ ? 1 : 0 );
-
+like(
+    $@,
+    qr/\QMust supply server and a port pairs. You supplied www.google.com\E/,
+    'got exception due to bad arguments',
+);

--- a/t/05_badarg.t
+++ b/t/05_badarg.t
@@ -1,6 +1,9 @@
 #!perl
 
 use Test::More tests => 1;
+
+delete $ENV{NO_NETWORK_TESTING};
+
 require Test::RequiresInternet;
 
 eval {


### PR DESCRIPTION
Ironically, this distribution does not install cleanly when `NO_NETWORK_TESTING` is set.

I also added a description for the test in the same file.
